### PR TITLE
Adding New Bitcoin v0.7 API Methods

### DIFF
--- a/lib/bitcoin/client.js
+++ b/lib/bitcoin/client.js
@@ -6,6 +6,8 @@ var rpc = require('../jsonrpc');
 var bitcoinAPI = {
   addMultiSigAddress: 'addmultisigaddress',
   backupWallet: 'backupwallet',
+  createRawTransaction: 'createrawtransaction', // Bitcoin v0.7+
+  decodeRawTransaction: 'decoderawtransaction', // Bitcoin v0.7+
   dumpPrivKey: 'dumpprivkey',
   encryptWallet: 'encryptwallet',
   getAccount: 'getaccount',
@@ -26,6 +28,9 @@ var bitcoinAPI = {
   getMemoryPool: 'getmemorypool',
   getMiningInfo: 'getmininginfo',
   getNewAddress: 'getnewaddress',
+  getPeerInfo: 'getpeerinfo', // Bitcoin v0.7+
+  getRawMemPool: 'getrawmempool', // Bitcoin v0.7+
+  getRawTransaction: 'getrawtransaction', // Bitcoin v0.7+
   getReceivedByAccount: 'getreceivedbyaccount',
   getReceivedByAddress: 'getreceivedbyaddress',
   getTransaction: 'gettransaction',
@@ -39,14 +44,17 @@ var bitcoinAPI = {
   listReceivedByAddress: 'listreceivedbyaddress',
   listSinceBlock: 'listsinceblock',
   listTransactions: 'listtransactions',
+  listUnspent: 'listunspent', // Bitcoin v0.7+
   move: 'move',
   sendFrom: 'sendfrom',
   sendMany: 'sendmany',
+  sendRawTransaction: 'sendrawtransaction', // Bitcoin v0.7+
   sendToAddress: 'sendtoaddress',
   setAccount: 'setaccount',
   setGenerate: 'setgenerate',
   setTxFee: 'settxfee',
   signMessage: 'signmessage',
+  signRawTransaction: 'signrawtransaction', // Bitcoin v0.7+
   stop: 'stop',
   validateAddress: 'validateaddress',
   verifyMessage: 'verifymessage',


### PR DESCRIPTION
Adding New Bitcoin v0.7 API Methods: createrawtransaction, decoderawtransaction, getpeerinfo, getrawmempool, getrawtransaction, listunspent, sendrawtransaction, signrawtransaction
