### PR TITLE
Fix for content-length issue when using special characters

### DIFF
--- a/lib/jsonrpc.js
+++ b/lib/jsonrpc.js
@@ -40,7 +40,7 @@ Client.prototype.call = function (method, params, callback, errback, path) {
     path: path || '/',
     headers: {
       'Host': this.opts.host || 'localhost',
-      'Content-Length': requestJSON.length
+      'Content-Length': Buffer.from(requestJSON).length
     },
     agent: false,
     rejectUnauthorized: this.opts.ssl && this.opts.sslStrict !== false


### PR DESCRIPTION
We encountered this error in the Syscoin project when users were attempting to decode wallets using password that contained special characters. The failing string was `Test!"£$%^&*()` but we narrowed it to a single offending character `£`. The root issue was that content-length was being calculated improperly prior to sending the request in this scenario, resulting in truncation of the JSON string and parse error. For more info see https://github.com/syscoin/blockmarket-desktop-public/issues/231#issuecomment-333333586.